### PR TITLE
List scans within a study

### DIFF
--- a/bruker2nifti/_cores.py
+++ b/bruker2nifti/_cores.py
@@ -6,8 +6,8 @@ import warnings
 
 from os.path import join as jph
 
-from ._getters import get_list_scans, nifti_getter
-from ._utils import bruker_read_files, normalise_b_vect, from_dict_to_txt_sorted, set_new_data, \
+from bruker2nifti._getters import get_list_scans, nifti_getter
+from bruker2nifti._utils import bruker_read_files, normalise_b_vect, from_dict_to_txt_sorted, set_new_data, \
     apply_reorientation_to_b_vects, obtain_b_vectors_orient_matrix
 
 

--- a/bruker2nifti/_getters.py
+++ b/bruker2nifti/_getters.py
@@ -2,7 +2,7 @@ import os
 import nibabel as nib
 import numpy as np
 
-from ._utils import bruker_read_files, eliminate_consecutive_duplicates, data_corrector, \
+from bruker2nifti._utils import bruker_read_files, eliminate_consecutive_duplicates, data_corrector, \
     compute_affine_from_visu_pars, compute_resolution_from_visu_pars
 
 

--- a/bruker2nifti/_metadata.py
+++ b/bruker2nifti/_metadata.py
@@ -37,7 +37,7 @@ list_recons() returns a list of recon numbers for a given scan
 """
 import os
 
-from . import _utils as utils
+import bruker2nifti._utils as utils
 
 class BrukerMetadata(object):
     """Represents metadata associated with a given MRI study."""

--- a/bruker2nifti/_utils.py
+++ b/bruker2nifti/_utils.py
@@ -106,10 +106,11 @@ def bruker_read_files(param_file, data_path, sub_scan_num='1'):
     :return: dict_info dictionary with the parsed information from the input file.
     """
     if param_file.lower() == 'reco':
-        if os.path.exists(jph(data_path, 'pdata', '1', 'reco')):
-            f = open(jph(data_path, 'pdata', '1', 'reco'), 'r')
+        if os.path.exists(jph(data_path, 'pdata', str(sub_scan_num), 'reco')):
+            f = open(jph(data_path, 'pdata', str(sub_scan_num), 'reco'), 'r')
         else:
-            print('File {} does not exist'.format(jph(data_path, 'pdata', '1', 'reco')))
+            print('File {} does not exist'.format(jph(data_path, 'pdata',
+              str(sub_scan_num), 'reco')))
             return {}
     elif param_file.lower() == 'acqp':
         if os.path.exists(jph(data_path, 'acqp')):

--- a/bruker2nifti/cli/bruker2nii.py
+++ b/bruker2nifti/cli/bruker2nii.py
@@ -1,8 +1,10 @@
 import os
 import sys
 import argparse
+from datetime import datetime
 from bruker2nifti.converter import Bruker2Nifti
 import bruker2nifti._utils as utils
+import bruker2nifti._getters as getters
 
 
 def main():
@@ -13,6 +15,18 @@ def main():
     """
 
     parser = argparse.ArgumentParser()
+
+    # The action to be taken
+    #  'convert': Convert images to nifti format (default)
+    #  'list': List scans without converting
+    parser.add_argument('command',
+                        type=str,
+                        nargs='?',
+                        default='convert',
+                        choices=['convert', 'list'],
+                        help='Action to take: ' +
+                          'convert - convert to nifti, ' +
+                          'list - list studies and exit')
 
     # custom helper
     parser.add_argument('-what',
@@ -104,6 +118,10 @@ def main():
     args = parser.parse_args()
 
     # Check input:
+    if args.command == 'list':
+        list_scans(args.pfo_input)
+        sys.exit(0)
+
     if args.what:
         msg = 'Code repository : {} \n' \
               'Documentation   : {}'.format('https://github.com/SebastianoF/bruker2nifti',
@@ -157,6 +175,17 @@ def main():
     if utils.path_contains_whitespace(bruconv.pfo_study_nifti_output,
       bruconv.study_name):
         print("INFO: Output path/filename contains whitespace")
+
+
+def list_scans(study):
+    scans = getters.get_list_scans(study, print_structure = False)
+
+    subject_data = utils.bruker_read_files("subject", study)
+    print("Subject: {}".format(subject_data["SUBJECT_name_string"]))
+    print("Study Date: {:%Y-%m-%d %H:%M}".format(
+      datetime.strptime(subject_data["SUBJECT_date"],
+        "%Y-%m-%dT%H:%M:%S,%f%z")))
+    print(scans)
 
 
 if __name__ == "__main__":

--- a/bruker2nifti/cli/bruker2nii.py
+++ b/bruker2nifti/cli/bruker2nii.py
@@ -5,7 +5,7 @@ import sys
 
 from bruker2nifti.converter import Bruker2Nifti
 import bruker2nifti._utils as utils
-from ..metadata import BrukerMetadata
+from bruker2nifti._metadata import BrukerMetadata
 
 
 def main():

--- a/bruker2nifti/converter.py
+++ b/bruker2nifti/converter.py
@@ -1,8 +1,8 @@
 import os
 
-from ._utils import bruker_read_files
-from ._getters import get_list_scans, get_subject_name
-from ._cores import scan2struct, write_struct
+from bruker2nifti._utils import bruker_read_files
+from bruker2nifti._getters import get_list_scans, get_subject_name
+from bruker2nifti._cores import scan2struct, write_struct
 
 
 class Bruker2Nifti(object):

--- a/bruker2nifti/metadata.py
+++ b/bruker2nifti/metadata.py
@@ -77,7 +77,7 @@ class BrukerMetadata(object):
 
         Reads the 'subject' metadata file within the root study folder. It
         populates a dictionary with the data where keys correspond to variables
-        within the source file (minus any '##'/'##$' decorators).
+        within the source file (minus any ##/$/PVM_ decorators).
         """
         return utils.bruker_read_files("subject", self.pfo_input)
 
@@ -101,7 +101,7 @@ class BrukerMetadata(object):
         sub-keyed with individual recon numbers, each of which is in turn keyed
         with 'reco' and 'visu_pars'. Beneath the appropriate key is a
         sub-dictionary keyed with variables from the source file (minus and
-        '##'/'##$' decorators).
+        ##/$/PVM_ decorators).
         """
         scan_data = {}
         data_path = os.path.join(self.pfo_input, scan)
@@ -131,7 +131,7 @@ class BrukerMetadata(object):
         reconstruction sub-directory and compiles a dictionary. At the top
         level the dictionary has keys corresponding to the two files and then
         the sub-dictionaries are keyed according to variables in the relevant
-        file (minus any ##/##$ decorators).
+        file (minus any ##/$/PVM_ decorators).
         """
         recon_data = {}
         data_path = os.path.join(self.pfo_input, scan)

--- a/bruker2nifti/metadata.py
+++ b/bruker2nifti/metadata.py
@@ -1,0 +1,183 @@
+"""
+Provides the BrukerMetadata class for reading Bruker MRI metadata.
+
+The BrukerMetadata class should be instantiated for each study. Dictionaries
+are structured as follows:
+
+subject_data {
+  [key_from_subject_file]: [corresponding_value]
+}
+
+scan_data {
+  [scan_number]: {
+    'acqp': { [key_from_acqp_file]: [corresponding_value] },
+    'method': { [key_from_method_file]: [corresponding_value] },
+    'recons': {
+      [recon_number]: {
+        'reco': { [key_from_reco_file]: [corresponding_value] },
+        'visu_pars': { [key_from_visu_pars_file]: [corresponding_value] }
+      }
+    }
+  }
+}
+
+parse_subject() creates the subject_data dictionary and stores it in the object
+parse_scans() creates the scan_data dictionary and stores it in the object
+
+read_subject() returns a subject_data dictionary
+read_scans() returns a scan_data dictionary
+read_scan() returns the sub-dictionary corresponding to [scan_number]
+read_recons() returns the sub-citionary corresponding to 'recons' for a given
+  [scan_number]
+read_recon() returns the sub-dictionary corresponding to [recon_number] for a
+  given [scan_number]
+
+list_scans() returns a list of scan numbers
+list_recons() returns a list of recon numbers for a given scan
+"""
+import os
+
+from . import _utils as utils
+
+class BrukerMetadata(object):
+    """Represents metadata associated with a given MRI study."""
+
+    def __init__(self, study):
+        """
+        Initialises a new object with the location of the study.
+
+        self.pfo_input stores the path to the root directory of a give MRI
+        study. The path is not checked for validity during initialisation.
+        """
+        self.pfo_input = study
+        self.subject_data = None
+        self.scan_data = None
+
+    def parse_subject(self):
+        """
+        Stores subject metadata in the object.
+
+        Reads the 'subject' file within the MRI study folder stores the
+        metadata in `self.subject_data`.
+        """
+        self.subject_data = self.read_subject()
+
+    def parse_scans(self):
+        """
+        Stores scan metadata in the object.
+
+        Reads all 'acqp', 'method', 'reco' and 'visu_pars' files to get all
+        scan metadata and store it in `self.study_data`.
+        """
+        self.scan_data = self.read_scans()
+
+    def read_subject(self):
+        """
+        Reads metadata from the 'subject' file and returns a dictionary.
+
+        Reads the 'subject' metadata file within the root study folder. It
+        populates a dictionary with the data where keys correspond to variables
+        within the source file (minus any '##'/'##$' decorators).
+        """
+        return utils.bruker_read_files("subject", self.pfo_input)
+
+    def read_scans(self):
+        """
+        Reads metadata for all scans of a study and returns a dictionary.
+
+        Reads all 'acqp', 'method', 'reco' and 'visu_pars' files for the study
+        and returns a nested dictionary containing all variables and their
+        values specified in those files.
+        """
+        return {scan: self.read_scan(scan) for scan in self.list_scans()}
+
+    def read_scan(self, scan):
+        """
+        Reads the metadata for a specified scan and returns a dictionary.
+
+        Reads 'acqp', 'method' and all 'reco' and 'visu_pars' files for a given
+        scan and its reconstructions. A dictionary of these values is returned.
+        The top level keys are 'acqp', 'method' and 'recons' where 'recons' is
+        sub-keyed with individual recon numbers, each of which is in turn keyed
+        with 'reco' and 'visu_pars'. Beneath the appropriate key is a
+        sub-dictionary keyed with variables from the source file (minus and
+        '##'/'##$' decorators).
+        """
+        scan_data = {}
+        data_path = os.path.join(self.pfo_input, scan)
+        scan_data["acqp"] = utils.bruker_read_files("acqp", data_path)
+        scan_data["method"] = utils.bruker_read_files("method", data_path)
+        scan_data["recons"] = self.read_recons(scan)
+        return scan_data
+
+    def read_recons(self, scan):
+        """
+        Reads the metadata for all recons and returns a dictionary.
+
+        Reads 'reco' and 'visu_pars' files from all recon sub-folders for the
+        given scan. The metadata is stored in a dictionary with top level
+        keys corresponding to reconstruction numbers.
+        """
+        recon_data = {}
+        for recon in self.list_recons(scan):
+            recon_data[recon] = self.read_recon(scan, recon)
+        return recon_data
+
+    def read_recon(self, scan, recon):
+        """
+        Reads the metadata from a specified recon and returns a dictionary.
+
+        Reads the 'reco' and 'visu_pars' files from within a specific
+        reconstruction sub-directory and compiles a dictionary. At the top
+        level the dictionary has keys corresponding to the two files and then
+        the sub-dictionaries are keyed according to variables in the relevant
+        file (minus any ##/##$ decorators).
+        """
+        recon_data = {}
+        data_path = os.path.join(self.pfo_input, scan)
+        recon_data["reco"] = utils.bruker_read_files("reco", data_path, recon)
+        recon_data["visu_pars"] = utils.bruker_read_files("visu_pars",
+          data_path, recon)
+        return recon_data
+
+    def list_scans(self):
+        """
+        Returns a list of scans that comprise this study.
+
+        Returns a list of strings corresponding to the numbered sub-directories
+        of the root study folder. Each of these sub-directories stores data for
+        an individual scan.
+
+        Note this function doesn't read the contents of the scan directories to
+        confirm that they contain valid scan data.
+        """
+        return self._list_subdirs(self.pfo_input)
+
+    def list_recons(self, scan):
+        """
+        Returns a list of recons for a given scan within this study.
+
+        Returns a list of strings corresponding to the numbered sub-directories
+        of the pdata sub-directory within the scan folder. Each of these
+        sub-directories stores data for an individual reconstruction.
+
+        Note this function doesn't read the contents of the reconstruction
+        directories to confirm that they contain valid reconstruction data.
+        """
+        pfo_recons = os.path.join(self.pfo_input, scan, "pdata")
+        return self._list_subdirs(pfo_recons)
+
+    def _list_subdirs(self, path):
+        """
+        Return a list of scan or reconstruction sub-directories.
+
+        Return a sorted list of strings corresponding to sub-directories of the
+        given path that could be either a scan or reconstruction. This is based
+        on the bruker convention of naming these as an integer.
+
+        Note this function does not read the contents of directories to confirm
+        that they contain scan or reconstruction data.
+        """
+        dirs = [d for d in os.listdir(path) if
+          os.path.isdir(os.path.join(path, d)) and d.isdigit()]
+        return sorted(dirs, key = int)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,1 @@
+from .fixtures.mri_data import banana_data

--- a/test/fixtures/mri_data.py
+++ b/test/fixtures/mri_data.py
@@ -1,0 +1,12 @@
+import os
+import shutil
+
+import pytest
+
+@pytest.fixture
+def banana_data(tmp_path, request):
+    input_dir = os.path.join(os.path.abspath(request.fspath.dirname), "..",
+      "test_data", "bru_banana")
+    output_dir = os.path.join(tmp_path, "bru_banana")
+    shutil.copytree(input_dir, output_dir)
+    return os.path.join(tmp_path, "bru_banana")

--- a/test/test_metadata.py
+++ b/test/test_metadata.py
@@ -3,7 +3,7 @@ import unittest.mock as mock
 
 import pytest
 
-from bruker2nifti.metadata import BrukerMetadata
+from bruker2nifti._metadata import BrukerMetadata
 from bruker2nifti._utils import bruker_read_files
 
 class TestMetadata(object):

--- a/test/test_metadata.py
+++ b/test/test_metadata.py
@@ -1,0 +1,152 @@
+import os
+import unittest.mock as mock
+
+import pytest
+
+from bruker2nifti.metadata import BrukerMetadata
+from bruker2nifti._utils import bruker_read_files
+
+class TestMetadata(object):
+
+    def test_instantiation(self):
+        paths = [
+            None,
+            "/",
+            os.path.join("path", "to", "study"),
+            os.path.join("path", "to", "study", "0"),
+            os.path.join("path", "to", "study", "1")
+        ]
+        for path in paths:
+            m = BrukerMetadata(path)
+            assert isinstance(m, BrukerMetadata)
+            assert m.pfo_input == path
+
+    def test_list_subdirs(self, banana_data):
+        m = BrukerMetadata(banana_data)
+        assert m._list_subdirs(banana_data) == ["1", "2", "3"]
+        assert m._list_subdirs(os.path.join(banana_data, "1")) == []
+        assert m._list_subdirs(os.path.join(banana_data, "1", "pdata")) == ["1"]
+        assert m._list_subdirs(os.path.join(banana_data, "1", "pdata", "1")) == []
+
+    def test_list_scans(self):
+        data_dir = os.path.join("path", "to", "study")
+        expected_scans = ["1", "2", "3", "4"]
+        with mock.patch.object(BrukerMetadata, "_list_subdirs",
+          return_value = expected_scans) as mock_method:
+            m = BrukerMetadata(data_dir)
+            scans = m.list_scans()
+            mock_method.assert_called_once_with(data_dir)
+            assert scans == expected_scans
+
+    def test_list_reconstructions(self):
+        data_dir = os.path.join("path", "to", "study")
+        selected_scan = "2"
+        expected_recons = ["1"]
+        expected_dir = os.path.join(data_dir, selected_scan, "pdata")
+        with mock.patch.object(BrukerMetadata, "_list_subdirs",
+          return_value = expected_recons) as mock_method:
+            m = BrukerMetadata(data_dir)
+            recons = m.list_recons(selected_scan)
+            mock_method.assert_called_once_with(expected_dir)
+            assert recons == expected_recons
+
+    # TODO: The following test case is not properly tested yet as the
+    #       banana dataset does not include a subject. Will need to add a new
+    #       test dataset or update banana to include a subject
+    def test_read_subject(self, banana_data):
+        expected_contents = bruker_read_files("subject", banana_data)
+        with mock.patch("bruker2nifti._utils.bruker_read_files") as mock_function:
+            mock_function.configure_mock(side_effect = bruker_read_files)
+            m = BrukerMetadata(banana_data)
+            subject = m.read_subject()
+            assert subject == expected_contents
+            mock_function.assert_called_once_with("subject", banana_data)
+
+    def test_read_recon(self, banana_data):
+        selected_scan = "3"
+        selected_recon = "1"
+        data_path = os.path.join(banana_data, selected_scan)
+        ex_reco = bruker_read_files("reco", data_path, selected_recon)
+        ex_visu_pars = bruker_read_files("visu_pars", data_path, selected_recon)
+        expected_contents = { "reco": ex_reco, "visu_pars": ex_visu_pars }
+        with mock.patch("bruker2nifti._utils.bruker_read_files") as mock_function:
+            mock_function.configure_mock(side_effect = bruker_read_files)
+            m = BrukerMetadata(banana_data)
+            recon = m.read_recon(selected_scan, selected_recon)
+            assert recon.keys() == expected_contents.keys()
+            assert recon["reco"].keys() == ex_reco.keys()
+            assert recon["visu_pars"].keys() == ex_visu_pars.keys()
+            mock_function.assert_called()
+
+    def test_read_recons(self):
+        selected_scan = "2"
+        root_path = os.path.join("path", "to")
+        data_path = os.path.join(root_path, selected_scan)
+        expected_keys = ["1", "2"]
+        with mock.patch.object(
+          BrukerMetadata, "list_recons",
+          return_value = ["1", "2"]) as mock_list_recons, mock.patch.object(
+          BrukerMetadata, "read_recon",
+          return_value = None) as mock_read_recon:
+            m = BrukerMetadata(root_path)
+            recons = m.read_recons(selected_scan)
+            assert list(recons.keys()) == expected_keys
+            mock_list_recons.assert_called_once()
+            mock_read_recon.assert_called()
+
+    def test_read_scan(self, banana_data):
+        selected_scan = "1"
+        data_path = os.path.join(banana_data, selected_scan)
+        expected_keys = ["acqp", "method", "recons"]
+        ex_acqp = bruker_read_files("acqp", data_path)
+        ex_method = bruker_read_files("method", data_path)
+        with mock.patch.object(BrukerMetadata, "read_recons",
+          return_value = { "1": None, "2": None }) as mock_read_recons:
+            m = BrukerMetadata(banana_data)
+            scan = m.read_scan(selected_scan)
+            assert list(scan.keys()) == expected_keys
+            assert scan["acqp"].keys() == ex_acqp.keys()
+            assert scan["method"].keys() == ex_method.keys()
+            assert list(scan["recons"].keys()) == ["1", "2"]
+            mock_read_recons.assert_called_once_with(selected_scan)
+
+    def test_read_scans(self):
+        expected_keys = ["1", "2", "3", "4"]
+        root_path = os.path.join("path", "to")
+        with mock.patch.object(
+          BrukerMetadata, "list_scans",
+          return_value = expected_keys) as mock_list_scans, mock.patch.object(
+          BrukerMetadata, "read_scan",
+          return_value = None) as mock_read_scan:
+            m = BrukerMetadata(root_path)
+            scans = m.read_scans()
+            assert list(scans.keys()) == expected_keys
+            mock_list_scans.assert_called_once()
+            mock_read_scan.assert_called()
+
+    def test_parse_scans(self):
+        root_path = os.path.join("path", "to")
+        expected_contents = {
+            "acqp": None,
+            "method": None,
+            "recons": None
+        }
+        with mock.patch.object(BrukerMetadata, "read_scans",
+          return_value = expected_contents) as mock_read_scans:
+            m = BrukerMetadata(root_path)
+            m.parse_scans()
+            assert m.scan_data == expected_contents
+            mock_read_scans.assert_called_once()
+
+    def test_parse_subject(self):
+        root_path = os.path.join("path", "to")
+        expected_contents = {
+            "OWNER": "nmrsu",
+            "SUBJECT_name": "Tom Bombadil",
+        }
+        with mock.patch.object(BrukerMetadata, "read_subject",
+          return_value = expected_contents) as mock_read_subject:
+            m = BrukerMetadata(root_path)
+            m.parse_subject()
+            assert m.subject_data == expected_contents
+            mock_read_subject.assert_called_once()


### PR DESCRIPTION
Hi,

Not sure if you are interested in this but I wanted a way to easily see some basic details about scans within a study. I needed this to help work out which scans within the study I actually wanted to convert and analyze. The first two commits in this pull request are a bare bones implementation. It just displays the subject name, scan date/time and the protocol/method/scan duration for each scan. The code to derive this information is generic for all UIs but only the CLI UI is modified to display this information. The command to do this is:

bruker2nifti list -i ...

The CLI UI is modified in such a way that the first argument ('list' in this case) is the command to run. 'convert' would convert the scan. If no command is specified it defaults to convert and so remains backwards compatible.

The third commit in this pull request is a little separate but just a small fix to listing scans for conversion. The current implementation only supports single digit scan ids. The option --scans can now be supplied which supports multi-digit scan ids. For backwards compatibility -scan_list is retained unmodified.

Cheers,
Jath
