### PR TITLE
replace deprecated nibabel get_data() method with get_fdata()

### DIFF
--- a/bruker2nifti/_cores.py
+++ b/bruker2nifti/_cores.py
@@ -504,7 +504,7 @@ def write_struct(
                 nib.save(
                     set_new_data(
                         bruker_struct["nib_scans_list"][i],
-                        bruker_struct["nib_scans_list"][i].get_data()[..., 0],
+                        bruker_struct["nib_scans_list"][i].get_fdata()[..., 0],
                     ),
                     pfi_scan_b0,
                 )


### PR DESCRIPTION
get_data() has been deprecated for quite some time, it might be good to replace it with get_fdata.
If the exact behavior of get_data is required in some cases, then the same line can instead be replaced with 

np.asanyarray(bruker_struct["nib_scans_list"][i].dataobj)[..., 0],